### PR TITLE
Fix automatica: 53376aa1-493a-411d-82b8-02d9d2a32551 - URIs should not be hardcoded

### DIFF
--- a/examples/example-exemplars-tail-sampling/example-hello-world-app/src/main/java/io/prometheus/metrics/examples/otel/exemplars/app/HelloWorldServlet.java
+++ b/examples/example-exemplars-tail-sampling/example-hello-world-app/src/main/java/io/prometheus/metrics/examples/otel/exemplars/app/HelloWorldServlet.java
@@ -55,8 +55,8 @@ public class HelloWorldServlet extends HttpServlet {
 
   private String executeGreetingServiceRequest()
       throws URISyntaxException, IOException, InterruptedException {
-    HttpRequest request =
-        HttpRequest.newBuilder().GET().uri(new URI("http://localhost:8081/")).build();
+    String uriString = System.getProperty("greeting.service.uri", "http://localhost:8081/");
+    HttpRequest request = HttpRequest.newBuilder().GET().uri(new URI(uriString)).build();
     HttpClient httpClient = HttpClient.newHttpClient();
     HttpResponse<String> response = httpClient.send(request, ofString());
     return response.body();


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **53376aa1-493a-411d-82b8-02d9d2a32551** relativa alla regola **URIs should not be hardcoded**.

File coinvolto: `examples/example-exemplars-tail-sampling/example-hello-world-app/src/main/java/io/prometheus/metrics/examples/otel/exemplars/app/HelloWorldServlet.java`

Si prega di rivedere e approvare.