### PR TITLE
Fix automatica: 24369cfc-38f8-4fa2-b1ca-258c6a10a3fb - Fields in a "Serializable" class should either be transient or serializable

### DIFF
--- a/examples/example-exemplars-tail-sampling/example-greeting-service/src/main/java/io/prometheus/metrics/examples/otel/exemplars/greeting/GreetingServlet.java
+++ b/examples/example-exemplars-tail-sampling/example-greeting-service/src/main/java/io/prometheus/metrics/examples/otel/exemplars/greeting/GreetingServlet.java
@@ -15,9 +15,9 @@ public class GreetingServlet extends HttpServlet {
 
   private static final long serialVersionUID = 0L;
 
-  private final Random random = new Random(0);
+  private final transient Random random = new Random(0);
 
-  private final Histogram histogram;
+  private final transient Histogram histogram;
 
   public GreetingServlet() {
     histogram =


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **24369cfc-38f8-4fa2-b1ca-258c6a10a3fb** relativa alla regola **Fields in a "Serializable" class should either be transient or serializable**.

File coinvolto: `examples/example-exemplars-tail-sampling/example-greeting-service/src/main/java/io/prometheus/metrics/examples/otel/exemplars/greeting/GreetingServlet.java`

Si prega di rivedere e approvare.