### PR TITLE
Fix automatica: 94c98377-17f2-43b2-9e03-30cbb76eca1f - Exceptions in "throws" clauses should not be superfluous

### DIFF
--- a/examples/example-exporter-multi-target/src/main/java/io/prometheus/metrics/examples/multitarget/Main.java
+++ b/examples/example-exporter-multi-target/src/main/java/io/prometheus/metrics/examples/multitarget/Main.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 /** Simple example of an application exposing metrics via Prometheus' built-in HTTPServer. */
 public class Main {
 
-  public static void main(String[] args) throws IOException, InterruptedException {
+  public static void main(String[] args) throws IOException {
 
     SampleMultiCollector xmc = new SampleMultiCollector();
     PrometheusRegistry.defaultRegistry.register(xmc);


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **94c98377-17f2-43b2-9e03-30cbb76eca1f** relativa alla regola **Exceptions in "throws" clauses should not be superfluous**.

File coinvolto: `examples/example-exporter-multi-target/src/main/java/io/prometheus/metrics/examples/multitarget/Main.java`

Si prega di rivedere e approvare.