### PR TITLE
Fix automatica: 994182f9-36c4-4604-9c12-b14ad9c2534b - The diamond operator ("<>") should be used

### DIFF
--- a/examples/example-exporter-multi-target/src/main/java/io/prometheus/metrics/examples/multitarget/SampleMultiCollector.java
+++ b/examples/example-exporter-multi-target/src/main/java/io/prometheus/metrics/examples/multitarget/SampleMultiCollector.java
@@ -79,7 +79,7 @@ public class SampleMultiCollector implements MultiCollector {
 
   @Override
   public List<String> getPrometheusNames() {
-    List<String> names = new ArrayList<String>();
+    List<String> names = new ArrayList<>();
     names.add("x_calls_total");
     names.add("x_load");
     return names;


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **994182f9-36c4-4604-9c12-b14ad9c2534b** relativa alla regola **The diamond operator ("<>") should be used**.

File coinvolto: `examples/example-exporter-multi-target/src/main/java/io/prometheus/metrics/examples/multitarget/SampleMultiCollector.java`

Si prega di rivedere e approvare.