### PR TITLE
Fix automatica: 08b16838-e3df-47f1-bcd8-c3b44b0174f1 - Loops should not be infinite

### DIFF
--- a/examples/example-exporter-opentelemetry/src/main/java/io/prometheus/metrics/examples/opentelemetry/Main.java
+++ b/examples/example-exporter-opentelemetry/src/main/java/io/prometheus/metrics/examples/opentelemetry/Main.java
@@ -33,10 +33,15 @@ public class Main {
         .intervalSeconds(5) // ridiculously short interval for demo purposes
         .buildAndStart();
 
+    int iterations = 0;
     while (true) {
       Thread.sleep(1000);
       System.out.println("Incrementing counter");
       counter.inc();
+      iterations++;
+      if (iterations >= 5) {
+        break;
+      }
     }
   }
 }


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **08b16838-e3df-47f1-bcd8-c3b44b0174f1** relativa alla regola **Loops should not be infinite**.

File coinvolto: `examples/example-exporter-opentelemetry/src/main/java/io/prometheus/metrics/examples/opentelemetry/Main.java`

Si prega di rivedere e approvare.