### PR TITLE
Fix automatica: 4f7da75d-c652-4c2f-8ec4-64d064f083d7 - Standard outputs should not be used directly to log anything

### DIFF
--- a/examples/example-exporter-opentelemetry/src/main/java/io/prometheus/metrics/examples/opentelemetry/Main.java
+++ b/examples/example-exporter-opentelemetry/src/main/java/io/prometheus/metrics/examples/opentelemetry/Main.java
@@ -4,12 +4,15 @@ import io.prometheus.metrics.core.metrics.Counter;
 import io.prometheus.metrics.exporter.opentelemetry.OpenTelemetryExporter;
 import io.prometheus.metrics.instrumentation.jvm.JvmMetrics;
 import io.prometheus.metrics.model.snapshots.Unit;
+import java.util.logging.Logger;
 
 /** Simple example of an application exposing metrics pushing metrics via OTLP. */
 public class Main {
 
+  private static final Logger logger = Logger.getLogger(Main.class.getName());
+
   public static void main(String[] args) throws Exception {
-    System.out.println("Starting example application");
+    logger.info("Starting example application");
 
     // Note: Some JVM metrics are also defined as OpenTelemetry's semantic conventions.
     // We have plans to implement a configuration option for JvmMetrics to use OpenTelemetry
@@ -35,7 +38,7 @@ public class Main {
 
     while (true) {
       Thread.sleep(1000);
-      System.out.println("Incrementing counter");
+      logger.info("Incrementing counter");
       counter.inc();
     }
   }


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **4f7da75d-c652-4c2f-8ec4-64d064f083d7** relativa alla regola **Standard outputs should not be used directly to log anything**.

File coinvolto: `examples/example-exporter-opentelemetry/src/main/java/io/prometheus/metrics/examples/opentelemetry/Main.java`

Si prega di rivedere e approvare.