### PR TITLE
Fix automatica: 317f36e5-e001-4a1a-b3c0-43568724ddf4 - "InterruptedException" and "ThreadDeath" should not be ignored

### DIFF
--- a/examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java
+++ b/examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java
@@ -49,6 +49,7 @@ public class HelloWorldServlet extends HttpServlet {
       resp.setContentType("text/plain");
       resp.getWriter().println("Hello, World!");
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new RuntimeException(e);
     } finally {
       counter.labelValues("200").inc();


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **317f36e5-e001-4a1a-b3c0-43568724ddf4** relativa alla regola **"InterruptedException" and "ThreadDeath" should not be ignored**.

File coinvolto: `examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java`

Si prega di rivedere e approvare.