### PR TITLE
Fix automatica: 08c30d8b-5543-468b-9190-64e780753ff9 - Standard outputs should not be used directly to log anything

### DIFF
--- a/examples/example-native-histogram/src/main/java/io/prometheus/metrics/examples/nativehistogram/Main.java
+++ b/examples/example-native-histogram/src/main/java/io/prometheus/metrics/examples/nativehistogram/Main.java
@@ -6,8 +6,11 @@ import io.prometheus.metrics.instrumentation.jvm.JvmMetrics;
 import io.prometheus.metrics.model.snapshots.Unit;
 import java.io.IOException;
 import java.util.Random;
+import java.util.logging.Logger;
 
 public class Main {
+
+  private static final Logger logger = Logger.getLogger(Main.class.getName());
 
   public static void main(String[] args) throws IOException, InterruptedException {
 
@@ -23,8 +26,7 @@ public class Main {
 
     HTTPServer server = HTTPServer.builder().port(9400).buildAndStart();
 
-    System.out.println(
-        "HTTPServer listening on port http://localhost:" + server.getPort() + "/metrics");
+    logger.info("HTTPServer listening on port http://localhost:" + server.getPort() + "/metrics");
 
     Random random = new Random(0);
 


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **08c30d8b-5543-468b-9190-64e780753ff9** relativa alla regola **Standard outputs should not be used directly to log anything**.

File coinvolto: `examples/example-native-histogram/src/main/java/io/prometheus/metrics/examples/nativehistogram/Main.java`

Si prega di rivedere e approvare.