### PR TITLE
Fix automatica: ac55c50f-20f2-45d0-8188-b6f119df3cef - Math operands should be cast before assignment

### DIFF
--- a/examples/example-prometheus-properties/src/main/java/io/prometheus/metrics/examples/prometheus_properties/Main.java
+++ b/examples/example-prometheus-properties/src/main/java/io/prometheus/metrics/examples/prometheus_properties/Main.java
@@ -36,7 +36,7 @@ public class Main {
 
     while (true) {
       double duration = Math.abs(random.nextGaussian() / 10.0 + 0.2);
-      double size = random.nextInt(1000) + 256;
+      double size = (double) random.nextInt(1000) + 256;
       requestDuration.observe(duration);
       requestSize.observe(size);
       Thread.sleep(1000);


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **ac55c50f-20f2-45d0-8188-b6f119df3cef** relativa alla regola **Math operands should be cast before assignment**.

File coinvolto: `examples/example-prometheus-properties/src/main/java/io/prometheus/metrics/examples/prometheus_properties/Main.java`

Si prega di rivedere e approvare.