### PR TITLE
Fix automatica: 6fa99938-84ac-4eca-8ba3-d09aa8ae178a - String literals should not be duplicated

### DIFF
--- a/integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java
+++ b/integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java
@@ -20,6 +20,9 @@ import javax.net.ssl.X509TrustManager;
 /** Example application using the {@link PushGateway}. */
 class PushGatewayTestApp {
 
+  private static final String PUSHING_METRICS = "Pushing metrics...";
+  private static final String PUSH_SUCCESSFUL = "Push successful.";
+
   public static void main(String[] args) throws IOException {
     if (args.length != 1) {
       System.err.println("Usage: java -jar pushgateway-test-app.jar <test>");
@@ -47,34 +50,34 @@ class PushGatewayTestApp {
   private static void runSimpleTest() throws IOException {
     makeMetrics();
     PushGateway pg = PushGateway.builder().build();
-    System.out.println("Pushing metrics...");
+    System.out.println(PUSHING_METRICS);
     pg.push();
-    System.out.println("Push successful.");
+    System.out.println(PUSH_SUCCESSFUL);
   }
 
   private static void runTextFormatTest() throws IOException {
     makeMetrics();
     PushGateway pg = PushGateway.builder().format(Format.PROMETHEUS_TEXT).build();
-    System.out.println("Pushing metrics...");
+    System.out.println(PUSHING_METRICS);
     pg.push();
-    System.out.println("Push successful.");
+    System.out.println(PUSH_SUCCESSFUL);
   }
 
   private static void runBasicAuthTest() throws IOException {
     makeMetrics();
     PushGateway pg = PushGateway.builder().basicAuth("my_user", "secret_password").build();
-    System.out.println("Pushing metrics...");
+    System.out.println(PUSHING_METRICS);
     pg.push();
-    System.out.println("Push successful.");
+    System.out.println(PUSH_SUCCESSFUL);
   }
 
   private static void runSslTest() throws IOException {
     makeMetrics();
     PushGateway pg =
         PushGateway.builder().scheme(HTTPS).connectionFactory(insecureConnectionFactory).build();
-    System.out.println("Pushing metrics...");
+    System.out.println(PUSHING_METRICS);
     pg.push();
-    System.out.println("Push successful.");
+    System.out.println(PUSH_SUCCESSFUL);
   }
 
   static TrustManager insecureTrustManager =


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **6fa99938-84ac-4eca-8ba3-d09aa8ae178a** relativa alla regola **String literals should not be duplicated**.

File coinvolto: `integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java`

Si prega di rivedere e approvare.