### PR TITLE
Fix automatica: ef64bd6f-880e-48a3-9ba7-08542af9b4ce - Server certificates should be verified during SSL/TLS connections

### DIFF
--- a/integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java
+++ b/integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java
@@ -9,11 +9,8 @@ import io.prometheus.metrics.exporter.pushgateway.HttpConnectionFactory;
 import io.prometheus.metrics.exporter.pushgateway.PushGateway;
 import io.prometheus.metrics.model.snapshots.Unit;
 import java.io.IOException;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
 import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
@@ -94,14 +91,9 @@ class PushGatewayTestApp {
   static HttpConnectionFactory insecureConnectionFactory =
       url -> {
         try {
-          SSLContext sslContext = SSLContext.getInstance("TLS");
-          sslContext.init(null, new TrustManager[] {insecureTrustManager}, null);
-          SSLContext.setDefault(sslContext);
-
           HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
-          connection.setHostnameVerifier((hostname, session) -> true);
           return connection;
-        } catch (NoSuchAlgorithmException | KeyManagementException e) {
+        } catch (IOException e) {
           throw new RuntimeException(e);
         }
       };


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **ef64bd6f-880e-48a3-9ba7-08542af9b4ce** relativa alla regola **Server certificates should be verified during SSL/TLS connections**.

File coinvolto: `integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java`

Si prega di rivedere e approvare.