### PR TITLE
Fix automatica: fa66616b-9375-47ba-a620-f31e5bb266b1 - Server hostnames should be verified during SSL/TLS connections

### DIFF
--- a/integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java
+++ b/integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java
@@ -99,7 +99,7 @@ class PushGatewayTestApp {
           SSLContext.setDefault(sslContext);
 
           HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
-          connection.setHostnameVerifier((hostname, session) -> true);
+          // Removed the insecure hostname verifier to allow default verification
           return connection;
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
           throw new RuntimeException(e);


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **fa66616b-9375-47ba-a620-f31e5bb266b1** relativa alla regola **Server hostnames should be verified during SSL/TLS connections**.

File coinvolto: `integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java`

Si prega di rivedere e approvare.