### PR TITLE
Fix automatica: 0c43a17c-13c2-4e61-9e06-ad968ced22ee - Generic exceptions should never be thrown

### DIFF
--- a/integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java
+++ b/integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java
@@ -91,6 +91,12 @@ class PushGatewayTestApp {
         public void checkServerTrusted(X509Certificate[] chain, String authType) {}
       };
 
+  static class SSLInitializationException extends RuntimeException {
+    public SSLInitializationException(String message, Throwable cause) {
+      super(message, cause);
+    }
+  }
+
   static HttpConnectionFactory insecureConnectionFactory =
       url -> {
         try {
@@ -102,7 +108,7 @@ class PushGatewayTestApp {
           connection.setHostnameVerifier((hostname, session) -> true);
           return connection;
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
-          throw new RuntimeException(e);
+          throw new SSLInitializationException("Failed to initialize SSL context", e);
         }
       };
 


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **0c43a17c-13c2-4e61-9e06-ad968ced22ee** relativa alla regola **Generic exceptions should never be thrown**.

File coinvolto: `integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java`

Si prega di rivedere e approvare.