### PR TITLE
Fix automatica: f88019e0-c071-46ae-ae24-78ada30cba67 - Methods should not be empty

### DIFF
--- a/benchmarks/src/main/java/io/prometheus/metrics/benchmarks/TextFormatUtilBenchmark.java
+++ b/benchmarks/src/main/java/io/prometheus/metrics/benchmarks/TextFormatUtilBenchmark.java
@@ -105,18 +105,28 @@ public class TextFormatUtilBenchmark {
     }
 
     @Override
-    public void write(int b) {}
+    public void write(int b) {
+      // Intentionally empty: this output stream discards all data
+    }
 
     @Override
-    public void write(byte[] b) {}
+    public void write(byte[] b) {
+      // Intentionally empty: this output stream discards all data
+    }
 
     @Override
-    public void write(byte[] b, int off, int len) {}
+    public void write(byte[] b, int off, int len) {
+      // Intentionally empty: this output stream discards all data
+    }
 
     @Override
-    public void flush() {}
+    public void flush() {
+      // Intentionally empty: this output stream discards all data
+    }
 
     @Override
-    public void close() {}
+    public void close() {
+      // Intentionally empty: this output stream discards all data
+    }
   }
 }


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **f88019e0-c071-46ae-ae24-78ada30cba67** relativa alla regola **Methods should not be empty**.

File coinvolto: `benchmarks/src/main/java/io/prometheus/metrics/benchmarks/TextFormatUtilBenchmark.java`

Si prega di rivedere e approvare.