### PR TITLE
Fix automatica: 20173e42-26c3-4a80-92f5-a7408fed8d30 - Fields in a "Serializable" class should either be transient or serializable

### DIFF
--- a/examples/example-exemplars-tail-sampling/example-hello-world-app/src/main/java/io/prometheus/metrics/examples/otel/exemplars/app/HelloWorldServlet.java
+++ b/examples/example-exemplars-tail-sampling/example-hello-world-app/src/main/java/io/prometheus/metrics/examples/otel/exemplars/app/HelloWorldServlet.java
@@ -22,9 +22,9 @@ public class HelloWorldServlet extends HttpServlet {
 
   private static final long serialVersionUID = 0L;
 
-  private final Random random = new Random(0);
+  private final transient Random random = new Random(0);
 
-  private final Histogram histogram;
+  private final transient Histogram histogram;
 
   public HelloWorldServlet() {
     histogram =


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **20173e42-26c3-4a80-92f5-a7408fed8d30** relativa alla regola **Fields in a "Serializable" class should either be transient or serializable**.

File coinvolto: `examples/example-exemplars-tail-sampling/example-hello-world-app/src/main/java/io/prometheus/metrics/examples/otel/exemplars/app/HelloWorldServlet.java`

Si prega di rivedere e approvare.