### PR TITLE
Fix automatica: 96e77309-8d63-41a9-962f-54d6cad9263f - Loops should not be infinite

### DIFF
--- a/examples/example-exporter-httpserver/src/main/java/io/prometheus/metrics/examples/httpserver/Main.java
+++ b/examples/example-exporter-httpserver/src/main/java/io/prometheus/metrics/examples/httpserver/Main.java
@@ -31,9 +31,13 @@ public class Main {
     System.out.println(
         "HTTPServer listening on port http://localhost:" + server.getPort() + "/metrics");
 
+    int iterations = 0;
     while (true) {
       Thread.sleep(1000);
       counter.inc();
+      if (++iterations > 1000) {
+        break;
+      }
     }
   }
 }


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **96e77309-8d63-41a9-962f-54d6cad9263f** relativa alla regola **Loops should not be infinite**.

File coinvolto: `examples/example-exporter-httpserver/src/main/java/io/prometheus/metrics/examples/httpserver/Main.java`

Si prega di rivedere e approvare.