### PR TITLE
Fix automatica: 952ac3df-0346-4265-a9df-4c50b1e4bed8 - Standard outputs should not be used directly to log anything

### DIFF
--- a/examples/example-exporter-multi-target/src/main/java/io/prometheus/metrics/examples/multitarget/Main.java
+++ b/examples/example-exporter-multi-target/src/main/java/io/prometheus/metrics/examples/multitarget/Main.java
@@ -3,6 +3,7 @@ package io.prometheus.metrics.examples.multitarget;
 import io.prometheus.metrics.exporter.httpserver.HTTPServer;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.io.IOException;
+import java.util.logging.Logger;
 
 /** Simple example of an application exposing metrics via Prometheus' built-in HTTPServer. */
 public class Main {
@@ -13,7 +14,7 @@ public class Main {
     PrometheusRegistry.defaultRegistry.register(xmc);
     HTTPServer server = HTTPServer.builder().port(9401).buildAndStart();
 
-    System.out.println(
-        "HTTPServer listening on port http://localhost:" + server.getPort() + "/metrics");
+    Logger.getLogger(Main.class.getName())
+        .info("HTTPServer listening on port http://localhost:" + server.getPort() + "/metrics");
   }
 }


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **952ac3df-0346-4265-a9df-4c50b1e4bed8** relativa alla regola **Standard outputs should not be used directly to log anything**.

File coinvolto: `examples/example-exporter-multi-target/src/main/java/io/prometheus/metrics/examples/multitarget/Main.java`

Si prega di rivedere e approvare.