### PR TITLE
Fix automatica: 0724beb5-dfca-4a44-9d40-ffa6a4ce998e - Deprecated elements should have both the annotation and the Javadoc tag

### DIFF
--- a/prometheus-metrics-instrumentation-caffeine/src/main/java/io/prometheus/metrics/instrumentation/caffeine/CacheMetricsCollector.java
+++ b/prometheus-metrics-instrumentation-caffeine/src/main/java/io/prometheus/metrics/instrumentation/caffeine/CacheMetricsCollector.java
@@ -95,6 +95,8 @@ public class CacheMetricsCollector implements MultiCollector {
    *
    * <p>Note that the {@link #builder()} API has different default values than this deprecated
    * constructor.
+   *
+   * @deprecated Use {@link #builder()} instead.
    */
   @Deprecated
   public CacheMetricsCollector() {


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **0724beb5-dfca-4a44-9d40-ffa6a4ce998e** relativa alla regola **Deprecated elements should have both the annotation and the Javadoc tag**.

File coinvolto: `prometheus-metrics-instrumentation-caffeine/src/main/java/io/prometheus/metrics/instrumentation/caffeine/CacheMetricsCollector.java`

Si prega di rivedere e approvare.