### PR TITLE
Fix automatica: f10e377a-55fe-469a-b4de-79ea55215ce1 - Fields in a "Serializable" class should either be transient or serializable

### DIFF
--- a/examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java
+++ b/examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java
@@ -20,14 +20,14 @@ public class HelloWorldServlet extends HttpServlet {
 
   // Note: The requests_total counter is not a great example, because the
   // request_duration_seconds histogram below also has a count with the number of requests.
-  private final Counter counter =
+  private final transient Counter counter =
       Counter.builder()
           .name("requests_total")
           .help("total number of requests")
           .labelNames("http_status")
           .register();
 
-  private final Histogram histogram =
+  private final transient Histogram histogram =
       Histogram.builder()
           .name("request_duration_seconds")
           .help("request duration in seconds")


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **f10e377a-55fe-469a-b4de-79ea55215ce1** relativa alla regola **Fields in a "Serializable" class should either be transient or serializable**.

File coinvolto: `examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java`

Si prega di rivedere e approvare.