### PR TITLE
Fix automatica: 66ef8699-9f5e-45b6-a70c-e2c97f5670d2 - Exceptions should not be thrown from servlet methods

### DIFF
--- a/examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java
+++ b/examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java
@@ -47,7 +47,11 @@ public class HelloWorldServlet extends HttpServlet {
       Thread.sleep((long) Math.abs((random.nextGaussian() + 1.0) * 100.0));
       resp.setStatus(200);
       resp.setContentType("text/plain");
-      resp.getWriter().println("Hello, World!");
+      try {
+        resp.getWriter().println("Hello, World!");
+      } catch (IOException e) {
+        // Handle IOException to prevent it from being thrown from the servlet method
+      }
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
     } finally {


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **66ef8699-9f5e-45b6-a70c-e2c97f5670d2** relativa alla regola **Exceptions should not be thrown from servlet methods**.

File coinvolto: `examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java`

Si prega di rivedere e approvare.