### PR TITLE
Fix automatica: 89777ff1-e425-4ccb-b20a-4409fd8a7d76 - Standard outputs should not be used directly to log anything

### DIFF
--- a/examples/example-simpleclient-bridge/src/main/java/io/prometheus/metrics/examples/simpleclient/Main.java
+++ b/examples/example-simpleclient-bridge/src/main/java/io/prometheus/metrics/examples/simpleclient/Main.java
@@ -4,6 +4,7 @@ import io.prometheus.client.Counter;
 import io.prometheus.metrics.exporter.httpserver.HTTPServer;
 import io.prometheus.metrics.simpleclient.bridge.SimpleclientCollector;
 import java.io.IOException;
+import java.util.logging.Logger;
 
 /** Simple example of the simpleclient backwards compatibility module. */
 public class Main {
@@ -28,8 +29,8 @@ public class Main {
 
     HTTPServer server = HTTPServer.builder().port(9400).buildAndStart();
 
-    System.out.println(
-        "HTTPServer listening on port http://localhost:" + server.getPort() + "/metrics");
+    Logger logger = Logger.getLogger(Main.class.getName());
+    logger.info("HTTPServer listening on port http://localhost:" + server.getPort() + "/metrics");
 
     Thread.currentThread().join();
   }


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **89777ff1-e425-4ccb-b20a-4409fd8a7d76** relativa alla regola **Standard outputs should not be used directly to log anything**.

File coinvolto: `examples/example-simpleclient-bridge/src/main/java/io/prometheus/metrics/examples/simpleclient/Main.java`

Si prega di rivedere e approvare.