### PR TITLE
Fix automatica: 0c43a17c-13c2-4e61-9e06-ad968ced22ee - Generic exceptions should never be thrown

### DIFF
--- a/integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java
+++ b/integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java
@@ -102,7 +102,7 @@ class PushGatewayTestApp {
           connection.setHostnameVerifier((hostname, session) -> true);
           return connection;
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
-          throw new RuntimeException(e);
+          throw new SslInitializationException(e);
         }
       };
 
@@ -123,5 +123,11 @@ class PushGatewayTestApp {
             .unit(Unit.SECONDS)
             .register();
     duration.set(0.5);
+  }
+
+  static class SslInitializationException extends RuntimeException {
+    public SslInitializationException(Throwable cause) {
+      super(cause);
+    }
   }
 }


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **0c43a17c-13c2-4e61-9e06-ad968ced22ee** relativa alla regola **Generic exceptions should never be thrown**.

File coinvolto: `integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java`

Si prega di rivedere e approvare.