### PR TITLE
Fix automatica: 4a9e3a8e-acb0-4c71-a8a7-20f313ee7a84 - JUnit5 test classes and methods should have default package visibility

### DIFF
--- a/integration-tests/it-pushgateway/src/test/java/io/prometheus/metrics/it/pushgateway/PushGatewayIT.java
+++ b/integration-tests/it-pushgateway/src/test/java/io/prometheus/metrics/it/pushgateway/PushGatewayIT.java
@@ -22,7 +22,7 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.MountableFile;
 
-public class PushGatewayIT {
+class PushGatewayIT {
 
   private GenericContainer<?> sampleAppContainer;
   private GenericContainer<?> pushGatewayContainer;
@@ -30,7 +30,7 @@ public class PushGatewayIT {
   private Volume sampleAppVolume;
 
   @BeforeEach
-  public void setUp() throws IOException, URISyntaxException {
+  void setUp() throws IOException, URISyntaxException {
     Network network = Network.newNetwork();
     sampleAppVolume = Volume.create("it-pushgateway").copy("pushgateway-test-app.jar");
     pushGatewayContainer =
@@ -56,7 +56,7 @@ public class PushGatewayIT {
   }
 
   @AfterEach
-  public void tearDown() throws IOException {
+  void tearDown() throws IOException {
     prometheusContainer.stop();
     pushGatewayContainer.stop();
     sampleAppContainer.stop();
@@ -66,7 +66,7 @@ public class PushGatewayIT {
   final OkHttpClient client = new OkHttpClient();
 
   @Test
-  public void testSimple() throws IOException, InterruptedException {
+  void testSimple() throws IOException, InterruptedException {
     pushGatewayContainer.start();
     sampleAppContainer
         .withCommand(
@@ -86,7 +86,7 @@ public class PushGatewayIT {
   }
 
   @Test
-  public void testTextFormat() throws IOException, InterruptedException {
+  void testTextFormat() throws IOException, InterruptedException {
     pushGatewayContainer.start();
     sampleAppContainer
         .withCommand(
@@ -106,7 +106,7 @@ public class PushGatewayIT {
   }
 
   @Test
-  public void testBasicAuth() throws IOException, InterruptedException {
+  void testBasicAuth() throws IOException, InterruptedException {
     pushGatewayContainer
         .withCopyFileToContainer(
             MountableFile.forClasspathResource("/pushgateway-basicauth.yaml"),
@@ -131,7 +131,7 @@ public class PushGatewayIT {
   }
 
   @Test
-  public void testSsl() throws InterruptedException, IOException {
+  void testSsl() throws InterruptedException, IOException {
     pushGatewayContainer
         .withCopyFileToContainer(
             MountableFile.forClasspathResource("/pushgateway-ssl.yaml"),
@@ -156,7 +156,7 @@ public class PushGatewayIT {
   }
 
   @Test
-  public void testProtobuf() throws IOException, InterruptedException {
+  void testProtobuf() throws IOException, InterruptedException {
     pushGatewayContainer.start();
     sampleAppContainer
         .withCommand(


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **4a9e3a8e-acb0-4c71-a8a7-20f313ee7a84** relativa alla regola **JUnit5 test classes and methods should have default package visibility**.

File coinvolto: `integration-tests/it-pushgateway/src/test/java/io/prometheus/metrics/it/pushgateway/PushGatewayIT.java`

Si prega di rivedere e approvare.