### PR TITLE
Fix automatica: e626699d-c1d0-4c94-8e2a-9d1b39bd2dfd - String literals should not be duplicated

### DIFF
--- a/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/ExemplarsProperties.java
+++ b/prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/ExemplarsProperties.java
@@ -9,6 +9,7 @@ public class ExemplarsProperties {
   private static final String MIN_RETENTION_PERIOD_SECONDS = "minRetentionPeriodSeconds";
   private static final String MAX_RETENTION_PERIOD_SECONDS = "maxRetentionPeriodSeconds";
   private static final String SAMPLE_INTERVAL_MILLISECONDS = "sampleIntervalMilliseconds";
+  private static final String EXPECTING_VALUE_GT_0 = "Expecting value > 0.";
 
   private final Integer minRetentionPeriodSeconds;
   private final Integer maxRetentionPeriodSeconds;
@@ -68,19 +69,19 @@ public class ExemplarsProperties {
     Util.assertValue(
         minRetentionPeriodSeconds,
         t -> t > 0,
-        "Expecting value > 0.",
+        EXPECTING_VALUE_GT_0,
         PREFIX,
         MIN_RETENTION_PERIOD_SECONDS);
     Util.assertValue(
         maxRetentionPeriodSeconds,
         t -> t > 0,
-        "Expecting value > 0.",
+        EXPECTING_VALUE_GT_0,
         PREFIX,
         MAX_RETENTION_PERIOD_SECONDS);
     Util.assertValue(
         sampleIntervalMilliseconds,
         t -> t > 0,
-        "Expecting value > 0.",
+        EXPECTING_VALUE_GT_0,
         PREFIX,
         SAMPLE_INTERVAL_MILLISECONDS);
 


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **e626699d-c1d0-4c94-8e2a-9d1b39bd2dfd** relativa alla regola **String literals should not be duplicated**.

File coinvolto: `prometheus-metrics-config/src/main/java/io/prometheus/metrics/config/ExemplarsProperties.java`

Si prega di rivedere e approvare.