### PR TITLE
Fix automatica: 1f5f00b0-7601-41c5-91cb-c098c409ddee - Methods should not be empty

### DIFF
--- a/benchmarks/src/main/java/io/prometheus/metrics/benchmarks/TextFormatUtilBenchmark.java
+++ b/benchmarks/src/main/java/io/prometheus/metrics/benchmarks/TextFormatUtilBenchmark.java
@@ -105,18 +105,28 @@ public class TextFormatUtilBenchmark {
     }
 
     @Override
-    public void write(int b) {}
+    public void write(int b) {
+      // No-op: this method does nothing as per NullOutputStream implementation
+    }
 
     @Override
-    public void write(byte[] b) {}
+    public void write(byte[] b) {
+      // No-op: this method does nothing as per NullOutputStream implementation
+    }
 
     @Override
-    public void write(byte[] b, int off, int len) {}
+    public void write(byte[] b, int off, int len) {
+      // No-op: this method does nothing as per NullOutputStream implementation
+    }
 
     @Override
-    public void flush() {}
+    public void flush() {
+      // No-op: this method does nothing as per NullOutputStream implementation
+    }
 
     @Override
-    public void close() {}
+    public void close() {
+      // No-op: this method does nothing as per NullOutputStream implementation
+    }
   }
 }


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **1f5f00b0-7601-41c5-91cb-c098c409ddee** relativa alla regola **Methods should not be empty**.

File coinvolto: `benchmarks/src/main/java/io/prometheus/metrics/benchmarks/TextFormatUtilBenchmark.java`

Si prega di rivedere e approvare.