### PR TITLE
Fix automatica: 40a0b26c-ffec-43ab-967b-c8597215499f - Utility classes should not have public constructors

### DIFF
--- a/prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/TextFormatUtil.java
+++ b/prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/TextFormatUtil.java
@@ -6,6 +6,10 @@ import java.io.Writer;
 
 public class TextFormatUtil {
 
+  private TextFormatUtil() {
+    // Prevent instantiation of utility class
+  }
+
   static void writeLong(Writer writer, long value) throws IOException {
     writer.append(Long.toString(value));
   }


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **40a0b26c-ffec-43ab-967b-c8597215499f** relativa alla regola **Utility classes should not have public constructors**.

File coinvolto: `prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/TextFormatUtil.java`

Si prega di rivedere e approvare.