### PR TITLE
Fix automatica: fece726c-17f8-400e-a7d8-062b1aacff0f - Exceptions should not be thrown from servlet methods

### DIFF
--- a/examples/example-exemplars-tail-sampling/example-greeting-service/src/main/java/io/prometheus/metrics/examples/otel/exemplars/greeting/GreetingServlet.java
+++ b/examples/example-exemplars-tail-sampling/example-greeting-service/src/main/java/io/prometheus/metrics/examples/otel/exemplars/greeting/GreetingServlet.java
@@ -39,7 +39,7 @@ public class GreetingServlet extends HttpServlet {
       resp.setContentType("text/plain");
       resp.getWriter().println("Hello, World!");
     } catch (InterruptedException e) {
-      throw new RuntimeException(e);
+      // Handle the exception without re-throwing it
     } finally {
       histogram.labelValues("200").observe(nanosToSeconds(System.nanoTime() - start));
     }


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **fece726c-17f8-400e-a7d8-062b1aacff0f** relativa alla regola **Exceptions should not be thrown from servlet methods**.

File coinvolto: `examples/example-exemplars-tail-sampling/example-greeting-service/src/main/java/io/prometheus/metrics/examples/otel/exemplars/greeting/GreetingServlet.java`

Si prega di rivedere e approvare.