### PR TITLE
Fix automatica: 34680470-3e29-42e3-92fd-8b5169ac71a1 - Generic exceptions should never be thrown

### DIFF
--- a/examples/example-exemplars-tail-sampling/example-greeting-service/src/main/java/io/prometheus/metrics/examples/otel/exemplars/greeting/GreetingServlet.java
+++ b/examples/example-exemplars-tail-sampling/example-greeting-service/src/main/java/io/prometheus/metrics/examples/otel/exemplars/greeting/GreetingServlet.java
@@ -39,7 +39,7 @@ public class GreetingServlet extends HttpServlet {
       resp.setContentType("text/plain");
       resp.getWriter().println("Hello, World!");
     } catch (InterruptedException e) {
-      throw new RuntimeException(e);
+      throw new IOException("Interrupted while sleeping", e);
     } finally {
       histogram.labelValues("200").observe(nanosToSeconds(System.nanoTime() - start));
     }


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **34680470-3e29-42e3-92fd-8b5169ac71a1** relativa alla regola **Generic exceptions should never be thrown**.

File coinvolto: `examples/example-exemplars-tail-sampling/example-greeting-service/src/main/java/io/prometheus/metrics/examples/otel/exemplars/greeting/GreetingServlet.java`

Si prega di rivedere e approvare.