### PR TITLE
Fix automatica: 99d34683-0087-4f20-8d8d-e74ce17e61c9 - Exceptions should not be thrown from servlet methods

### DIFF
--- a/examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java
+++ b/examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java
@@ -41,7 +41,7 @@ public class HelloWorldServlet extends HttpServlet {
   }
 
   @Override
-  protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
     long start = System.nanoTime();
     try {
       Thread.sleep((long) Math.abs((random.nextGaussian() + 1.0) * 100.0));
@@ -50,6 +50,8 @@ public class HelloWorldServlet extends HttpServlet {
       resp.getWriter().println("Hello, World!");
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
+    } catch (IOException e) {
+      // Handle IOException that may be thrown by getWriter()
     } finally {
       counter.labelValues("200").inc();
       histogram.labelValues("200").observe(nanosToSeconds(System.nanoTime() - start));


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **99d34683-0087-4f20-8d8d-e74ce17e61c9** relativa alla regola **Exceptions should not be thrown from servlet methods**.

File coinvolto: `examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java`

Si prega di rivedere e approvare.