### PR TITLE
Fix automatica: 4f2d2f5c-5ad9-4017-8d98-75e37648ad05 - Methods should not be empty

### DIFF
--- a/integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java
+++ b/integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java
@@ -85,10 +85,14 @@ class PushGatewayTestApp {
         }
 
         @Override
-        public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+        public void checkClientTrusted(X509Certificate[] chain, String authType) {
+          // Intentionally empty to bypass client certificate validation
+        }
 
         @Override
-        public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {
+          // Intentionally empty to bypass server certificate validation
+        }
       };
 
   static HttpConnectionFactory insecureConnectionFactory =


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **4f2d2f5c-5ad9-4017-8d98-75e37648ad05** relativa alla regola **Methods should not be empty**.

File coinvolto: `integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java`

Si prega di rivedere e approvare.