### PR TITLE
Fix automatica: a7f14262-eaaf-4b20-b761-419bd33b4aa9 - Server certificates should be verified during SSL/TLS connections

### DIFF
--- a/integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java
+++ b/integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java
@@ -11,11 +11,8 @@ import io.prometheus.metrics.model.snapshots.Unit;
 import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
-import java.security.cert.X509Certificate;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
 
 /** Example application using the {@link PushGateway}. */
 class PushGatewayTestApp {
@@ -77,25 +74,11 @@ class PushGatewayTestApp {
     System.out.println("Push successful.");
   }
 
-  static TrustManager insecureTrustManager =
-      new X509TrustManager() {
-        @Override
-        public java.security.cert.X509Certificate[] getAcceptedIssuers() {
-          return null;
-        }
-
-        @Override
-        public void checkClientTrusted(X509Certificate[] chain, String authType) {}
-
-        @Override
-        public void checkServerTrusted(X509Certificate[] chain, String authType) {}
-      };
-
   static HttpConnectionFactory insecureConnectionFactory =
       url -> {
         try {
           SSLContext sslContext = SSLContext.getInstance("TLS");
-          sslContext.init(null, new TrustManager[] {insecureTrustManager}, null);
+          sslContext.init(null, null, null);
           SSLContext.setDefault(sslContext);
 
           HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **a7f14262-eaaf-4b20-b761-419bd33b4aa9** relativa alla regola **Server certificates should be verified during SSL/TLS connections**.

File coinvolto: `integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java`

Si prega di rivedere e approvare.