### PR TITLE
Fix automatica: d27a4416-8162-4087-a5b4-973ff0083894 - String literals should not be duplicated

### DIFF
--- a/benchmarks/src/main/java/io/prometheus/metrics/benchmarks/CounterBenchmark.java
+++ b/benchmarks/src/main/java/io/prometheus/metrics/benchmarks/CounterBenchmark.java
@@ -41,6 +41,12 @@ import org.openjdk.jmh.annotations.Threads;
  */
 public class CounterBenchmark {
 
+  private static final String COUNTER_HELP = "help";
+  private static final String PATH_KEY = "path";
+  private static final String STATUS_KEY = "status";
+  private static final String PATH_VALUE = "/";
+  private static final String STATUS_VALUE = "200";
+
   @State(Scope.Benchmark)
   public static class PrometheusCounter {
 
@@ -48,11 +54,11 @@ public class CounterBenchmark {
     final CounterDataPoint dataPoint;
 
     public PrometheusCounter() {
-      noLabels = Counter.builder().name("test").help("help").build();
+      noLabels = Counter.builder().name("test").help(COUNTER_HELP).build();
 
       Counter labels =
-          Counter.builder().name("test").help("help").labelNames("path", "status").build();
-      this.dataPoint = labels.labelValues("/", "200");
+          Counter.builder().name("test").help(COUNTER_HELP).labelNames("path", "status").build();
+      this.dataPoint = labels.labelValues(PATH_VALUE, STATUS_VALUE);
     }
   }
 
@@ -63,16 +69,16 @@ public class CounterBenchmark {
     final io.prometheus.client.Counter.Child dataPoint;
 
     public SimpleclientCounter() {
-      noLabels = io.prometheus.client.Counter.build().name("name").help("help").create();
+      noLabels = io.prometheus.client.Counter.build().name("name").help(COUNTER_HELP).create();
 
       io.prometheus.client.Counter counter =
           io.prometheus.client.Counter.build()
               .name("name")
-              .help("help")
+              .help(COUNTER_HELP)
               .labelNames("path", "status")
               .create();
 
-      this.dataPoint = counter.labels("/", "200");
+      this.dataPoint = counter.labels(PATH_VALUE, STATUS_VALUE);
     }
   }
 
@@ -107,8 +113,8 @@ public class CounterBenchmark {
       this.doubleCounter = meter.counterBuilder("test2").ofDoubles().setDescription("test").build();
       this.attributes =
           Attributes.of(
-              AttributeKey.stringKey("path"), "/",
-              AttributeKey.stringKey("status"), "200");
+              AttributeKey.stringKey(PATH_KEY), PATH_VALUE,
+              AttributeKey.stringKey(STATUS_KEY), STATUS_VALUE);
     }
   }
 


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **d27a4416-8162-4087-a5b4-973ff0083894** relativa alla regola **String literals should not be duplicated**.

File coinvolto: `benchmarks/src/main/java/io/prometheus/metrics/benchmarks/CounterBenchmark.java`

Si prega di rivedere e approvare.