### PR TITLE
Fix automatica: f88019e0-c071-46ae-ae24-78ada30cba67 - Methods should not be empty

### DIFF
--- a/benchmarks/src/main/java/io/prometheus/metrics/benchmarks/TextFormatUtilBenchmark.java
+++ b/benchmarks/src/main/java/io/prometheus/metrics/benchmarks/TextFormatUtilBenchmark.java
@@ -105,18 +105,28 @@ public class TextFormatUtilBenchmark {
     }
 
     @Override
-    public void write(int b) {}
+    public void write(int b) {
+      // Do nothing as this is a null output stream
+    }
 
     @Override
-    public void write(byte[] b) {}
+    public void write(byte[] b) {
+      // Do nothing as this is a null output stream
+    }
 
     @Override
-    public void write(byte[] b, int off, int len) {}
+    public void write(byte[] b, int off, int len) {
+      // Do nothing as this is a null output stream
+    }
 
     @Override
-    public void flush() {}
+    public void flush() {
+      // Do nothing as this is a null output stream
+    }
 
     @Override
-    public void close() {}
+    public void close() {
+      // Do nothing as this is a null output stream
+    }
   }
 }


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **f88019e0-c071-46ae-ae24-78ada30cba67** relativa alla regola **Methods should not be empty**.

File coinvolto: `benchmarks/src/main/java/io/prometheus/metrics/benchmarks/TextFormatUtilBenchmark.java`

Si prega di rivedere e approvare.