### PR TITLE
Fix automatica: f51749f3-e305-44f8-b83b-cf6c7605f462 - Methods should not be empty

### DIFF
--- a/benchmarks/src/main/java/io/prometheus/metrics/benchmarks/TextFormatUtilBenchmark.java
+++ b/benchmarks/src/main/java/io/prometheus/metrics/benchmarks/TextFormatUtilBenchmark.java
@@ -105,18 +105,28 @@ public class TextFormatUtilBenchmark {
     }
 
     @Override
-    public void write(int b) {}
+    public void write(int b) {
+      // This method is intentionally empty as it represents a null output stream.
+    }
 
     @Override
-    public void write(byte[] b) {}
+    public void write(byte[] b) {
+      // This method is intentionally empty as it represents a null output stream.
+    }
 
     @Override
-    public void write(byte[] b, int off, int len) {}
+    public void write(byte[] b, int off, int len) {
+      // This method is intentionally empty as it represents a null output stream.
+    }
 
     @Override
-    public void flush() {}
+    public void flush() {
+      // This method is intentionally empty as it represents a null output stream.
+    }
 
     @Override
-    public void close() {}
+    public void close() {
+      // This method is intentionally empty as it represents a null output stream.
+    }
   }
 }


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **f51749f3-e305-44f8-b83b-cf6c7605f462** relativa alla regola **Methods should not be empty**.

File coinvolto: `benchmarks/src/main/java/io/prometheus/metrics/benchmarks/TextFormatUtilBenchmark.java`

Si prega di rivedere e approvare.