### PR TITLE
Fix automatica: 9ffce9de-159f-44de-8018-507788f656d7 - Generic exceptions should never be thrown

### DIFF
--- a/examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java
+++ b/examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java
@@ -49,7 +49,7 @@ public class HelloWorldServlet extends HttpServlet {
       resp.setContentType("text/plain");
       resp.getWriter().println("Hello, World!");
     } catch (InterruptedException e) {
-      throw new RuntimeException(e);
+      throw new IOException("Interrupted during sleep", e);
     } finally {
       counter.labelValues("200").inc();
       histogram.labelValues("200").observe(nanosToSeconds(System.nanoTime() - start));


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **9ffce9de-159f-44de-8018-507788f656d7** relativa alla regola **Generic exceptions should never be thrown**.

File coinvolto: `examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java`

Si prega di rivedere e approvare.