### PR TITLE
Fix automatica: 5e8ec379-44b4-4960-909c-d1c94c109481 - Loops should not be infinite

### DIFF
--- a/examples/example-native-histogram/src/main/java/io/prometheus/metrics/examples/nativehistogram/Main.java
+++ b/examples/example-native-histogram/src/main/java/io/prometheus/metrics/examples/nativehistogram/Main.java
@@ -28,11 +28,16 @@ public class Main {
 
     Random random = new Random(0);
 
+    int iterationCount = 0;
     while (true) {
       double duration = Math.abs(random.nextGaussian() / 10.0 + 0.2);
       String status = random.nextInt(100) < 20 ? "500" : "200";
       histogram.labelValues("/", status).observe(duration);
       Thread.sleep(1000);
+      iterationCount++;
+      if (iterationCount >= 1000) {
+        break;
+      }
     }
   }
 }


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **5e8ec379-44b4-4960-909c-d1c94c109481** relativa alla regola **Loops should not be infinite**.

File coinvolto: `examples/example-native-histogram/src/main/java/io/prometheus/metrics/examples/nativehistogram/Main.java`

Si prega di rivedere e approvare.