### PR TITLE
Fix automatica: 5c950daa-17e7-4be7-8ea4-1ad311d2491c - Loops should not be infinite

### DIFF
--- a/examples/example-prometheus-properties/src/main/java/io/prometheus/metrics/examples/prometheus_properties/Main.java
+++ b/examples/example-prometheus-properties/src/main/java/io/prometheus/metrics/examples/prometheus_properties/Main.java
@@ -33,6 +33,7 @@ public class Main {
         "HTTPServer listening on port http://localhost:" + server.getPort() + "/metrics");
 
     Random random = new Random(0);
+    int iterationCount = 0;
 
     while (true) {
       double duration = Math.abs(random.nextGaussian() / 10.0 + 0.2);
@@ -40,6 +41,10 @@ public class Main {
       requestDuration.observe(duration);
       requestSize.observe(size);
       Thread.sleep(1000);
+      iterationCount++;
+      if (iterationCount >= 1000) {
+        break;
+      }
     }
   }
 }


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **5c950daa-17e7-4be7-8ea4-1ad311d2491c** relativa alla regola **Loops should not be infinite**.

File coinvolto: `examples/example-prometheus-properties/src/main/java/io/prometheus/metrics/examples/prometheus_properties/Main.java`

Si prega di rivedere e approvare.