### PR TITLE
Fix automatica: a475a812-1cf4-4ed9-bdc7-432482c418a6 - Empty arrays and collections should be returned instead of null

### DIFF
--- a/integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java
+++ b/integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java
@@ -81,7 +81,7 @@ class PushGatewayTestApp {
       new X509TrustManager() {
         @Override
         public java.security.cert.X509Certificate[] getAcceptedIssuers() {
-          return null;
+          return new java.security.cert.X509Certificate[0];
         }
 
         @Override


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **a475a812-1cf4-4ed9-bdc7-432482c418a6** relativa alla regola **Empty arrays and collections should be returned instead of null**.

File coinvolto: `integration-tests/it-pushgateway/src/main/java/io/prometheus/metrics/it/pushgateway/PushGatewayTestApp.java`

Si prega di rivedere e approvare.