### PR TITLE
Fix automatica: 27234673-d0f7-470c-a039-cea45bcded9c - Methods should not be empty

### DIFF
--- a/benchmarks/src/main/java/io/prometheus/metrics/benchmarks/TextFormatUtilBenchmark.java
+++ b/benchmarks/src/main/java/io/prometheus/metrics/benchmarks/TextFormatUtilBenchmark.java
@@ -105,18 +105,28 @@ public class TextFormatUtilBenchmark {
     }
 
     @Override
-    public void write(int b) {}
+    public void write(int b) {
+      // This method intentionally does nothing as it represents a null output stream
+    }
 
     @Override
-    public void write(byte[] b) {}
+    public void write(byte[] b) {
+      // This method intentionally does nothing as it represents a null output stream
+    }
 
     @Override
-    public void write(byte[] b, int off, int len) {}
+    public void write(byte[] b, int off, int len) {
+      // This method intentionally does nothing as it represents a null output stream
+    }
 
     @Override
-    public void flush() {}
+    public void flush() {
+      // This method intentionally does nothing as it represents a null output stream
+    }
 
     @Override
-    public void close() {}
+    public void close() {
+      // This method intentionally does nothing as it represents a null output stream
+    }
   }
 }


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **27234673-d0f7-470c-a039-cea45bcded9c** relativa alla regola **Methods should not be empty**.

File coinvolto: `benchmarks/src/main/java/io/prometheus/metrics/benchmarks/TextFormatUtilBenchmark.java`

Si prega di rivedere e approvare.