### PR TITLE
Fix automatica: 440edb19-6c2d-42d0-8e2e-51101ce997ca - "InterruptedException" and "ThreadDeath" should not be ignored

### DIFF
--- a/examples/example-exemplars-tail-sampling/example-greeting-service/src/main/java/io/prometheus/metrics/examples/otel/exemplars/greeting/GreetingServlet.java
+++ b/examples/example-exemplars-tail-sampling/example-greeting-service/src/main/java/io/prometheus/metrics/examples/otel/exemplars/greeting/GreetingServlet.java
@@ -39,6 +39,7 @@ public class GreetingServlet extends HttpServlet {
       resp.setContentType("text/plain");
       resp.getWriter().println("Hello, World!");
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new RuntimeException(e);
     } finally {
       histogram.labelValues("200").observe(nanosToSeconds(System.nanoTime() - start));


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **440edb19-6c2d-42d0-8e2e-51101ce997ca** relativa alla regola **"InterruptedException" and "ThreadDeath" should not be ignored**.

File coinvolto: `examples/example-exemplars-tail-sampling/example-greeting-service/src/main/java/io/prometheus/metrics/examples/otel/exemplars/greeting/GreetingServlet.java`

Si prega di rivedere e approvare.