### PR TITLE
Fix automatica: 1624f4d1-90fd-4709-84ce-9e98bece8edb - "InterruptedException" and "ThreadDeath" should not be ignored

### DIFF
--- a/examples/example-exemplars-tail-sampling/example-hello-world-app/src/main/java/io/prometheus/metrics/examples/otel/exemplars/app/HelloWorldServlet.java
+++ b/examples/example-exemplars-tail-sampling/example-hello-world-app/src/main/java/io/prometheus/metrics/examples/otel/exemplars/app/HelloWorldServlet.java
@@ -46,6 +46,8 @@ public class HelloWorldServlet extends HttpServlet {
       resp.setStatus(200);
       resp.setContentType("text/plain");
       resp.getWriter().print(greeting);
+    } catch (InterruptedException e) {
+      throw new ServletException("Thread interrupted", e);
     } catch (Exception e) {
       throw new ServletException(e);
     } finally {


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **1624f4d1-90fd-4709-84ce-9e98bece8edb** relativa alla regola **"InterruptedException" and "ThreadDeath" should not be ignored**.

File coinvolto: `examples/example-exemplars-tail-sampling/example-hello-world-app/src/main/java/io/prometheus/metrics/examples/otel/exemplars/app/HelloWorldServlet.java`

Si prega di rivedere e approvare.