### PR TITLE
Fix automatica: ea35e5b3-4d07-46bf-8ae7-99e6e62f057b - "switch" statements should have "default" clauses

### DIFF
--- a/prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/TextFormatUtil.java
+++ b/prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/TextFormatUtil.java
@@ -87,6 +87,9 @@ public class TextFormatUtil {
           writer.write("\\n");
           newlineIndex = s.indexOf('\n', start);
           break;
+        default:
+          // No action needed for other characters.
+          break;
       }
 
       allEscapesIndex = backslashIndex & quoteIndex & newlineIndex;


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **ea35e5b3-4d07-46bf-8ae7-99e6e62f057b** relativa alla regola **"switch" statements should have "default" clauses**.

File coinvolto: `prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/TextFormatUtil.java`

Si prega di rivedere e approvare.