### PR TITLE
Fix automatica: f74e766b-ffb8-419c-bd5c-b7bb7d69fb59 - Sections of code should not be commented out

### DIFF
--- a/prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/TextFormatUtil.java
+++ b/prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/TextFormatUtil.java
@@ -17,7 +17,6 @@ public class TextFormatUtil {
       writer.write("-Inf");
     } else {
       writer.write(Double.toString(d));
-      // FloatingDecimal.getBinaryToASCIIConverter(d).appendTo(writer);
     }
   }
 


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **f74e766b-ffb8-419c-bd5c-b7bb7d69fb59** relativa alla regola **Sections of code should not be commented out**.

File coinvolto: `prometheus-metrics-exposition-textformats/src/main/java/io/prometheus/metrics/expositionformats/TextFormatUtil.java`

Si prega di rivedere e approvare.