### PR TITLE
Fix automatica: a01419fb-5e4e-4e12-9c74-5b5b96e1ff88 - Fields in a "Serializable" class should either be transient or serializable

### DIFF
--- a/examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java
+++ b/examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java
@@ -12,22 +12,22 @@ import java.io.IOException;
 import java.util.Random;
 
 /** Hello World REST servlet, with an example counter and an example histogram. */
-public class HelloWorldServlet extends HttpServlet {
+public class HelloWorldServlet extends HttpServlet implements java.io.Serializable {
 
   private static final long serialVersionUID = 0L;
 
-  private final Random random = new Random(0);
+  private final transient Random random = new Random(0);
 
   // Note: The requests_total counter is not a great example, because the
   // request_duration_seconds histogram below also has a count with the number of requests.
-  private final Counter counter =
+  private final transient Counter counter =
       Counter.builder()
           .name("requests_total")
           .help("total number of requests")
           .labelNames("http_status")
           .register();
 
-  private final Histogram histogram =
+  private final transient Histogram histogram =
       Histogram.builder()
           .name("request_duration_seconds")
           .help("request duration in seconds")


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **a01419fb-5e4e-4e12-9c74-5b5b96e1ff88** relativa alla regola **Fields in a "Serializable" class should either be transient or serializable**.

File coinvolto: `examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java`

Si prega di rivedere e approvare.