### PR TITLE
Fix automatica: 66ef8699-9f5e-45b6-a70c-e2c97f5670d2 - Exceptions should not be thrown from servlet methods

### DIFF
--- a/examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java
+++ b/examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java
@@ -50,6 +50,8 @@ public class HelloWorldServlet extends HttpServlet {
       resp.getWriter().println("Hello, World!");
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
     } finally {
       counter.labelValues("200").inc();
       histogram.labelValues("200").observe(nanosToSeconds(System.nanoTime() - start));


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **66ef8699-9f5e-45b6-a70c-e2c97f5670d2** relativa alla regola **Exceptions should not be thrown from servlet methods**.

File coinvolto: `examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java`

Si prega di rivedere e approvare.