### PR TITLE
Fix automatica: 99d34683-0087-4f20-8d8d-e74ce17e61c9 - Exceptions should not be thrown from servlet methods

### DIFF
--- a/examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java
+++ b/examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java
@@ -49,7 +49,7 @@ public class HelloWorldServlet extends HttpServlet {
       resp.setContentType("text/plain");
       resp.getWriter().println("Hello, World!");
     } catch (InterruptedException e) {
-      throw new RuntimeException(e);
+      // Handle the exception without rethrowing
     } finally {
       counter.labelValues("200").inc();
       histogram.labelValues("200").observe(nanosToSeconds(System.nanoTime() - start));


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **99d34683-0087-4f20-8d8d-e74ce17e61c9** relativa alla regola **Exceptions should not be thrown from servlet methods**.

File coinvolto: `examples/example-exporter-servlet-tomcat/src/main/java/io/prometheus/metrics/examples/tomcat_servlet/HelloWorldServlet.java`

Si prega di rivedere e approvare.