### PR TITLE
Fix automatica: 0ad1a679-5b8c-4974-9ea1-5686fe67c87c - Standard outputs should not be used directly to log anything

### DIFF
--- a/examples/example-prometheus-properties/src/main/java/io/prometheus/metrics/examples/prometheus_properties/Main.java
+++ b/examples/example-prometheus-properties/src/main/java/io/prometheus/metrics/examples/prometheus_properties/Main.java
@@ -6,6 +6,7 @@ import io.prometheus.metrics.instrumentation.jvm.JvmMetrics;
 import io.prometheus.metrics.model.snapshots.Unit;
 import java.io.IOException;
 import java.util.Random;
+import java.util.logging.Logger;
 
 public class Main {
 
@@ -29,8 +30,8 @@ public class Main {
 
     HTTPServer server = HTTPServer.builder().port(9400).buildAndStart();
 
-    System.out.println(
-        "HTTPServer listening on port http://localhost:" + server.getPort() + "/metrics");
+    Logger logger = Logger.getLogger(Main.class.getName());
+    logger.info("HTTPServer listening on port http://localhost:" + server.getPort() + "/metrics");
 
     Random random = new Random(0);
 


### PR DESCRIPTION
Questa Pull Request contiene una fix autogenerata per l'issue SonarQube **0ad1a679-5b8c-4974-9ea1-5686fe67c87c** relativa alla regola **Standard outputs should not be used directly to log anything**.

File coinvolto: `examples/example-prometheus-properties/src/main/java/io/prometheus/metrics/examples/prometheus_properties/Main.java`

Si prega di rivedere e approvare.